### PR TITLE
Add SECURITY

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Notice
+
+This is the security notice for all DfE (Department for Education) repositories. The notice explains how vulnerabilities should be reported to the DfE. At the DfE there are cyber security and information assurance teams, as well as security-conscious people within the programmes, that assess and triage all reported vulnerabilities.
+
+## Reporting a Vulnerability
+
+The Department for Education is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
+
+Send details to [admin@digital.education.gov.uk](mailto:admin@digital.education.gov.uk), including:
+
+* the website, page or repository where the vulnerability can be observed
+* a brief description of the vulnerability
+* optionally, the type of vulnerability and any related [OWASP category](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_2017_Project)
+* non-destructive exploitation details
+
+## Scope
+
+The following are **not** in scope:
+
+* volumetric vulnerabilities, for example overwhelming a service with a high volume of requests
+* reports indicating that our services do not fully align with "best practice", for example missing security headers
+
+If you are not sure, you can still contact us via email at [admin@digital.education.gov.uk](mailto:admin@digital.education.gov.uk).
+
+## Bug bounty
+
+Unfortunately, the DfE doesn't offer a paid bug bounty programme. The DfE will make efforts to show appreciation to people who take the time and effort to disclose vulnerabilities responsibly.
+
+## Code of Conduct
+
+The DfE has a contributors code of conduct, which you can find here: [CODE_OF_CONDUCT.md](https://github.com/dfe-digital/.github/blob/master/CODE_OF_CONDUCT.md)
+
+---
+
+### Further reading and inspiration about responsible disclosure and `SECURITY.md`
+
+* [https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy]
+* [https://www.ncsc.gov.uk/information/vulnerability-reporting]
+* [https://github.com/Trewaters/security-README]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Send details to [admin@digital.education.gov.uk](mailto:admin@digital.education.
 
 * the website, page or repository where the vulnerability can be observed
 * a brief description of the vulnerability
-* optionally, the type of vulnerability and any related [OWASP category](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_2017_Project)
+* optionally, the type of vulnerability and any related [OWASP category](https://owasp.org/www-community/vulnerabilities/)
 * non-destructive exploitation details
 
 ## Scope

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This is the security notice for all DfE (Department for Education) repositories.
 
 The Department for Education is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
 
-Send details to [admin@digital.education.gov.uk](mailto:admin@digital.education.gov.uk), including:
+Send details to opensource@digital.education.gov.uk, including:
 
 * the website, page or repository where the vulnerability can be observed
 * a brief description of the vulnerability
@@ -20,7 +20,7 @@ The following are **not** in scope:
 * volumetric vulnerabilities, for example overwhelming a service with a high volume of requests
 * reports indicating that our services do not fully align with "best practice", for example missing security headers
 
-If you are not sure, you can still contact us via email at [admin@digital.education.gov.uk](mailto:admin@digital.education.gov.uk).
+If you are not sure, you can still contact us via email at opensource@digital.education.gov.uk.
 
 ## Bug bounty
 


### PR DESCRIPTION
This was lifted from [the AlphaGov repo](https://github.com/alphagov/.github/blob/main/SECURITY.md) and references to GDS/the cabinet office have been switched for DfE.
