### PR TITLE
fixed the incorrect link to DfE's vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,5 @@ DfE has a contributors [code of conduct](https://github.com/dfe-digital/.github/
 ---
 
 ### Further reading and inspiration about responsible disclosure and `SECURITY.md`
-
-* [Ministry of Justice vulnerability disclosure policy](https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy)
+* [Department for Education vulnerability disclosure policy](https://www.gov.uk/guidance/report-a-vulnerability-on-a-department-for-education-system)
 * [NCSC vulnerability reporting](https://www.ncsc.gov.uk/information/vulnerability-reporting)


### PR DESCRIPTION
inadvertent link to MoJ policy fixed to correctly point to DfE's VDP policy